### PR TITLE
add missing frequencies for Eachine Nano VTX

### DIFF
--- a/tables/eachine/eachine-nano-vtx-fcc.json
+++ b/tables/eachine/eachine-nano-vtx-fcc.json
@@ -1,0 +1,101 @@
+{
+    "description": "Betaflight VTX Config file for the Eachine Nano VTX (Unlocked/Global version)",
+    "version": "1.0",
+    "vtx_table": {
+        "bands_list": [
+            {
+                "name": "BOSCAM_A",
+                "letter": "A",
+                "is_factory_band": true,
+                "frequencies": [
+                    5865,
+                    5845,
+                    5825,
+                    5805,
+                    5785,
+                    5765,
+                    5745,
+                    5725
+                ]
+            },
+            {
+                "name": "BOSCAM_B",
+                "letter": "B",
+                "is_factory_band": true,
+                "frequencies": [
+                    5733,
+                    5752,
+                    5771,
+                    5790,
+                    5809,
+                    5828,
+                    5847,
+                    5866
+                ]
+            },
+            {
+                "name": "BOSCAM_E",
+                "letter": "E",
+                "is_factory_band": true,
+                "frequencies": [
+                    5705,
+                    5685,
+                    5665,
+                    5645,
+                    5885,
+                    5905,
+                    5925,
+                    5945
+                ]
+            },
+            {
+                "name": "FATSHARK",
+                "letter": "F",
+                "is_factory_band": true,
+                "frequencies": [
+                    5740,
+                    5760,
+                    5780,
+                    5800,
+                    5820,
+                    5840,
+                    5860,
+                    5880
+                ]
+            },
+            {
+                "name": "RACEBAND",
+                "letter": "R",
+                "is_factory_band": true,
+                "frequencies": [
+                    5658,
+                    5695,
+                    5732,
+                    5769,
+                    5806,
+                    5843,
+                    5880,
+                    5917
+                ]
+            }
+        ],
+        "powerlevels_list": [
+            {
+                "value": 25,
+                "label": "25"
+            },
+            {
+                "value": 100,
+                "label": "100"
+            },
+            {
+                "value": 200,
+                "label": "200"
+            },
+            {
+                "value": 400,
+                "label": "400"
+            }
+        ]
+    }
+}

--- a/tables/eachine/eachine-nano-vtx-global.json
+++ b/tables/eachine/eachine-nano-vtx-global.json
@@ -77,6 +77,21 @@
                     5880,
                     5917
                 ]
+            },
+            {
+                "name": "Low Band",
+                "letter": "L",
+                "is_factory_band": true,
+                "frequencies": [
+                    5362,
+                    5399,
+                    5436,
+                    5473,
+                    5510,
+                    5547,
+                    5584,
+                    5621
+                ]
             }
         ],
         "powerlevels_list": [


### PR DESCRIPTION
Hi,
I did copy the Low Band frequency definitions from the manual.
I bought the VTX ca. in Dec. 2019 from Bangood, so I guess its a recent production charge.
(see attached screenshot; at the bottom).

According to FCC, these are illegal in the US, so I did create an 'fcc' version of the file.
Referring to FCC spec at 
https://www.ecfr.gov/cgi-bin/text-idx?SID=eed706a2c49fd9271106c3228b0615f3&mc=true&node=pt47.1.15&rgn=div5
(§15.245 ... §15.290)

![IMG_1824](https://user-images.githubusercontent.com/1189394/74110524-9aee4580-4b8d-11ea-8d26-c29586eda45d.jpg)
