### PR TITLE
Fix typo and add EU version for TBS Unify Pro32 Nano

### DIFF
--- a/tables/tbs/tbs-unify-pro32-nano-5g8-eu.json
+++ b/tables/tbs/tbs-unify-pro32-nano-5g8-eu.json
@@ -1,0 +1,67 @@
+{
+    "description": "Betaflight VTX Config file for TBS Unify Pro32 5G8 Nano (EU version)",
+    "version": "1.0",
+    "vtx_table": {
+        "bands_list": [
+            {
+                "name": "BOSCAM_A",
+                "letter": "A",
+                "is_factory_band": true,
+                "frequencies": [
+                    5865,
+                    5845,
+                    5825,
+                    5805,
+                    5785,
+                    5765,
+                    5745
+                ]
+            },
+            {
+                "name": "BOSCAM_B",
+                "letter": "B",
+                "is_factory_band": true,
+                "frequencies": [
+                    5733,
+                    5752,
+                    5771,
+                    5790,
+                    5809,
+                    5828,
+                    5847,
+                    5866
+                ]
+            },
+            {
+                "name": "FATSHARK",
+                "letter": "F",
+                "is_factory_band": true,
+                "frequencies": [
+                    5740,
+                    5760,
+                    5780,
+                    5800,
+                    5820,
+                    5840,
+                    5860
+                ]
+            },
+            {
+                "name": "RACEBAND",
+                "letter": "R",
+                "is_factory_band": true,
+                "frequencies": [
+                    5769,
+                    5806,
+                    5843
+                ]
+            }
+        ],
+        "powerlevels_list": [
+            {
+                "value": 14,
+                "label": "25"
+            }
+        ]
+    }
+}

--- a/tables/tbs/tbs-unify-pro32-nano-5g8-global.json
+++ b/tables/tbs/tbs-unify-pro32-nano-5g8-global.json
@@ -1,5 +1,5 @@
 {
-    "description": "Betaflight VTX Config file for TBS Unify Pro32 HV (MMCX) (Unlocked/Global version)",
+    "description": "Betaflight VTX Config file for TBS Unify Pro32 5G8 Nano (Unlocked/Global version)",
     "version": "1.0",
     "vtx_table": {
         "bands_list": [


### PR DESCRIPTION
fix title in TBS Unify Pro32 Nano global version
add EU version for TBS Unify Pro32 Nano
frequency table EU reference https://www.team-blacksheep.com/tbs-unify-pro32-manual-de.pdf

