### PR TITLE
Add VTX support for ewrf 7082VM v12 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Aomway |
 [Caddx](/tables/caddx) |
 [Eachine](/tables/eachine) |
 [EMAX](/tables/emax) |
+[EWRF](/tables/ewrf) |
 FuriousFPV |
 FXT |
 [Happymodel](/tables/happymodel) |

--- a/tables/ewrf/ewrf-e7082VM-v12.json
+++ b/tables/ewrf/ewrf-e7082VM-v12.json
@@ -1,0 +1,112 @@
+{
+    "description": "Betaflight VTX Config file",
+    "version": "1.0",
+    "vtx_table": {
+        "bands_list": [
+            {
+                "name": "BOSCAM_A",
+                "letter": "A",
+                "is_factory_band": true,
+                "frequencies": [
+                    5865,
+                    5845,
+                    5825,
+                    5805,
+                    5785,
+                    5765,
+                    5745,
+                    5725
+                ]
+            },
+            {
+                "name": "BOSCAM_B",
+                "letter": "B",
+                "is_factory_band": true,
+                "frequencies": [
+                    5733,
+                    5752,
+                    5771,
+                    5790,
+                    5809,
+                    5828,
+                    5847,
+                    5866
+                ]
+            },
+            {
+                "name": "BOSCAM_E",
+                "letter": "E",
+                "is_factory_band": true,
+                "frequencies": [
+                    5705,
+                    5685,
+                    5665,
+                    5645,
+                    5885,
+                    5905,
+                    5925,
+                    5945
+                ]
+            },
+            {
+                "name": "FATSHARK",
+                "letter": "F",
+                "is_factory_band": true,
+                "frequencies": [
+                    5740,
+                    5760,
+                    5780,
+                    5800,
+                    5820,
+                    5840,
+                    5860,
+                    5880
+                ]
+            },
+            {
+                "name": "RACEBAND",
+                "letter": "R",
+                "is_factory_band": true,
+                "frequencies": [
+                    5658,
+                    5695,
+                    5732,
+                    5769,
+                    5806,
+                    5843,
+                    5880,
+                    5917
+                ]
+            },
+            {
+                "name": "LOWRACE ",
+                "letter": "L",
+                "is_factory_band": true,
+                "frequencies": [
+                    5333,
+                    5373,
+                    5413,
+                    5453,
+                    5493,
+                    5533,
+                    5573,
+                    5613
+                ]
+            }
+        ],
+        "powerlevels_list": [
+            {
+                "value": 14,
+                "label": "25 "
+            },
+            {
+                "value": 20,
+                "label": "100"
+            },
+            {
+                "value": 24,
+                "label": "250"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
vtxtable for the original hardware before flashing to openvtx.