### PR TITLE
add band D to caddx firefly

### DIFF
--- a/tables/caddx/caddx-firefly-global.json
+++ b/tables/caddx/caddx-firefly-global.json
@@ -77,6 +77,21 @@
                     5880,
                     5917
                 ]
+            },
+            {
+                "name": "DIATONE ",
+                "letter": "D",
+                "is_factory_band": true,
+                "frequencies": [
+                    5362,
+                    5399,
+                    5436,
+                    5473,
+                    5510,
+                    5547,
+                    5584,
+                    5621
+                ]
             }
         ],
         "powerlevels_list": [


### PR DESCRIPTION
I found 1 band is missing.
I used these references, two for the frequency numbers.
And Oscar Liang's table for the channel name.

## caddx channel numbers references:
* https://flexrc.com/product/caddx-firefly/
* https://hobbyking.com/en_us/caddx-firefly-fpv-camera-and-vtx-pal-4-3.html

## naming reference
* https://oscarliang.com/fpv-channels/