### PR TITLE
Update rush-tank-ultimate-plus-global.json

### DIFF
--- a/tables/rush/rush-tank-ultimate-plus-global.json
+++ b/tables/rush/rush-tank-ultimate-plus-global.json
@@ -96,19 +96,19 @@
         ],
         "powerlevels_list": [
             {
-                "value": 0,
+                "value": 14,
                 "label": "25 "
             },
             {
-                "value": 1,
+                "value": 23,
                 "label": "200"
             },
             {
-                "value": 2,
+                "value": 27,
                 "label": "500"
             },
             {
-                "value": 3,
+                "value": 29,
                 "label": "800"
             }
         ]


### PR DESCRIPTION
Values for power levels are wrong and that causes random vtx behavior like not being able to turn off pit mode,change power by pressing the button on vtx,change power using smart audio,inability to switch to third and forth power level.