### PR TITLE
add betafpv tables

### DIFF
--- a/tables/betafpv/betafpv-M03-V1.0-global.json
+++ b/tables/betafpv/betafpv-M03-V1.0-global.json
@@ -1,0 +1,101 @@
+{
+    "description": "Betaflight VTX Config file for BetaFPV M03 V1.0",
+    "version": "1.0",
+    "vtx_table": {
+        "bands_list": [
+            {
+                "name": "BOSCAM_A",
+                "letter": "A",
+                "is_factory_band": true,
+                "frequencies": [
+                    5865,
+                    5845,
+                    5825,
+                    5805,
+                    5785,
+                    5765,
+                    5745,
+                    5725
+                ]
+            },
+            {
+                "name": "BOSCAM_B",
+                "letter": "B",
+                "is_factory_band": true,
+                "frequencies": [
+                    5733,
+                    5752,
+                    5771,
+                    5790,
+                    5809,
+                    5828,
+                    5847,
+                    5866
+                ]
+            },
+            {
+                "name": "BOSCAM_E",
+                "letter": "E",
+                "is_factory_band": true,
+                "frequencies": [
+                    5705,
+                    5685,
+                    5665,
+                    5645,
+                    5885,
+                    5905,
+                    5925,
+                    5945
+                ]
+            },
+            {
+                "name": "FATSHARK",
+                "letter": "F",
+                "is_factory_band": true,
+                "frequencies": [
+                    5740,
+                    5760,
+                    5780,
+                    5800,
+                    5820,
+                    5840,
+                    5860,
+                    5880
+                ]
+            },
+            {
+                "name": "RACEBAND",
+                "letter": "R",
+                "is_factory_band": true,
+                "frequencies": [
+                    5658,
+                    5695,
+                    5732,
+                    5769,
+                    5806,
+                    5843,
+                    5880,
+                    5917
+                ]
+            }
+        ],
+        "powerlevels_list": [
+            {
+                "value": 0,
+                "label": "25"
+            },
+            {
+                "value": 1,
+                "label": "100"
+            },
+            {
+                "value": 2,
+                "label": "200"
+            },
+            {
+                "value": 3,
+                "label": "350"
+            }
+        ]
+    }
+}

--- a/tables/betafpv/betafpv-M03-V1.1-global.json
+++ b/tables/betafpv/betafpv-M03-V1.1-global.json
@@ -1,0 +1,105 @@
+{
+    "description": "Betaflight VTX Config file for BetaFPV M03 V1.1",
+    "version": "1.0",
+    "vtx_table": {
+        "bands_list": [
+            {
+                "name": "BOSCAM_A",
+                "letter": "A",
+                "is_factory_band": true,
+                "frequencies": [
+                    5865,
+                    5845,
+                    5825,
+                    5805,
+                    5785,
+                    5765,
+                    5745,
+                    5725
+                ]
+            },
+            {
+                "name": "BOSCAM_B",
+                "letter": "B",
+                "is_factory_band": true,
+                "frequencies": [
+                    5733,
+                    5752,
+                    5771,
+                    5790,
+                    5809,
+                    5828,
+                    5847,
+                    5866
+                ]
+            },
+            {
+                "name": "BOSCAM_E",
+                "letter": "E",
+                "is_factory_band": true,
+                "frequencies": [
+                    5705,
+                    5685,
+                    5665,
+                    5645,
+                    5885,
+                    5905,
+                    5925,
+                    5945
+                ]
+            },
+            {
+                "name": "FATSHARK",
+                "letter": "F",
+                "is_factory_band": true,
+                "frequencies": [
+                    5740,
+                    5760,
+                    5780,
+                    5800,
+                    5820,
+                    5840,
+                    5860,
+                    5880
+                ]
+            },
+            {
+                "name": "RACEBAND",
+                "letter": "R",
+                "is_factory_band": true,
+                "frequencies": [
+                    5658,
+                    5695,
+                    5732,
+                    5769,
+                    5806,
+                    5843,
+                    5880,
+                    5917
+                ]
+            }
+        ],
+        "powerlevels_list": [
+            {
+                "value": 1,
+                "label": "25"
+            },
+            {
+                "value": 0,
+                "label": "PIT"
+            },
+            {
+                "value": 2,
+                "label": "100"
+            },
+            {
+                "value": 3,
+                "label": "200"
+            },
+            {
+                "value": 4,
+                "label": "400"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
I've converted two tables for the BETAFPV M03 VTX. The original `txt` config files were downloaded from [here](https://support.betafpv.com/hc/en-us/articles/4410949062809-CLI-for-VTX). The M03 VTX comes in two versions that are both included here.